### PR TITLE
Fix: log arrow function parameter

### DIFF
--- a/lib/console-log.coffee
+++ b/lib/console-log.coffee
@@ -84,12 +84,12 @@ module.exports =
         functionCheckSelection = editor.getSelectedText()
         objectCheckSelection = functionCheckSelection.split ''
 
+        if '(' not in lineTextBeforeSelectedText
+          objectFlag = true
+
         for val in functionCheckValues
           if functionCheckSelection.indexOf(val) > -1
             objectFlag = false
-
-        if '(' not in lineTextBeforeSelectedText
-          objectFlag = true
 
         if functionCheckSelection.match(new RegExp('^if[ (]'))
           objectFlag = false


### PR DESCRIPTION
When not surrounded by parenthesis, arrow function parameter was logged after the function instead of inside the function body.

Fixes #24